### PR TITLE
Comment unnecessary lines and fix segfault

### DIFF
--- a/src/Panes/Keyboard.vala
+++ b/src/Panes/Keyboard.vala
@@ -20,7 +20,7 @@
  * Authored by: Felipe Escoto <felescoto95@hotmail.com>
  */
 public class Accessibility.Panes.Keyboard : Categories.Pane {
-    private Gtk.Switch lk_notification;
+    // private Gtk.Switch lk_notification;
     private Gtk.Switch lk_beep;
     private Gtk.Switch mk_enable;
     private Gtk.Switch mk_beep;
@@ -41,7 +41,7 @@ public class Accessibility.Panes.Keyboard : Categories.Pane {
         kb_settings_label.vexpand = true;
 
         var lock_box = new Accessibility.Widgets.SettingsBox ();
-        //lk_notification = lock_box.add_switch (_("Display notifications for lock keys"));
+        // lk_notification = lock_box.add_switch (_("Display notifications for lock keys"));
         lk_beep = lock_box.add_switch (_("Beep when a lock key is pressed"));
 
         var modifier_box = new Accessibility.Widgets.SettingsBox ();
@@ -57,7 +57,7 @@ public class Accessibility.Panes.Keyboard : Categories.Pane {
     }
 
     private void connect_signals () {
-        lk_notification.set_sensitive (false);
+        // lk_notification.set_sensitive (false);
         keyboard_settings.schema.bind ("togglekeys-enable", lk_beep, "active", SettingsBindFlags.DEFAULT);
         keyboard_settings.schema.bind ("stickykeys-enable", mk_enable, "active", SettingsBindFlags.DEFAULT);
         keyboard_settings.schema.bind ("stickykeys-modifier-beep", mk_beep, "active", SettingsBindFlags.DEFAULT);

--- a/src/Panes/Keyboard.vala
+++ b/src/Panes/Keyboard.vala
@@ -20,7 +20,6 @@
  * Authored by: Felipe Escoto <felescoto95@hotmail.com>
  */
 public class Accessibility.Panes.Keyboard : Categories.Pane {
-    // private Gtk.Switch lk_notification;
     private Gtk.Switch lk_beep;
     private Gtk.Switch mk_enable;
     private Gtk.Switch mk_beep;
@@ -41,7 +40,6 @@ public class Accessibility.Panes.Keyboard : Categories.Pane {
         kb_settings_label.vexpand = true;
 
         var lock_box = new Accessibility.Widgets.SettingsBox ();
-        // lk_notification = lock_box.add_switch (_("Display notifications for lock keys"));
         lk_beep = lock_box.add_switch (_("Beep when a lock key is pressed"));
 
         var modifier_box = new Accessibility.Widgets.SettingsBox ();
@@ -57,7 +55,6 @@ public class Accessibility.Panes.Keyboard : Categories.Pane {
     }
 
     private void connect_signals () {
-        // lk_notification.set_sensitive (false);
         keyboard_settings.schema.bind ("togglekeys-enable", lk_beep, "active", SettingsBindFlags.DEFAULT);
         keyboard_settings.schema.bind ("stickykeys-enable", mk_enable, "active", SettingsBindFlags.DEFAULT);
         keyboard_settings.schema.bind ("stickykeys-modifier-beep", mk_beep, "active", SettingsBindFlags.DEFAULT);

--- a/src/Panes/Pointing.vala
+++ b/src/Panes/Pointing.vala
@@ -20,7 +20,6 @@
  * Authored by: Felipe Escoto <felescoto95@hotmail.com>
  */
 public class Accessibility.Panes.Pointing : Categories.Pane {
-    // private Gtk.ComboBox cursor_size;
     private Gtk.Switch keypad_control;
     private Gtk.Scale speed_scale;
     private Gtk.Adjustment speed_adjustment;
@@ -41,14 +40,10 @@ public class Accessibility.Panes.Pointing : Categories.Pane {
         var mouse_settings_label = new Accessibility.Widgets.LinkLabel (_("Mouse settings…"), "settings://input/mouse");
         mouse_settings_label.vexpand = true;
 
-        // var cursor_box = new Accessibility.Widgets.SettingsBox ();
-        // cursor_size = cursor_box.add_combo_box (_("Cursor size"));
-
         var control_box = new Accessibility.Widgets.SettingsBox ();
         keypad_control = control_box.add_switch (_("Control pointer using keypad"));
         speed_scale = control_box.add_scale (_("Cursor speed"), speed_adjustment);
 
-        // grid.add (cursor_box);
         grid.add (control_label);
         grid.add (control_box);
         grid.add (mouse_settings_label);
@@ -66,10 +61,6 @@ public class Accessibility.Panes.Pointing : Categories.Pane {
         list_store.set (iter, 0, _("Large"));
         list_store.append (out iter);
         list_store.set (iter, 0, _("Larger"));
-
-        // cursor_size.set_model (list_store);
-        // cursor_size.set_active (1);
-        // cursor_size.set_sensitive (false);
     }
 
     private void connect_signals () {

--- a/src/Panes/Pointing.vala
+++ b/src/Panes/Pointing.vala
@@ -20,7 +20,7 @@
  * Authored by: Felipe Escoto <felescoto95@hotmail.com>
  */
 public class Accessibility.Panes.Pointing : Categories.Pane {
-    private Gtk.ComboBox cursor_size;
+    // private Gtk.ComboBox cursor_size;
     private Gtk.Switch keypad_control;
     private Gtk.Scale speed_scale;
     private Gtk.Adjustment speed_adjustment;
@@ -41,14 +41,14 @@ public class Accessibility.Panes.Pointing : Categories.Pane {
         var mouse_settings_label = new Accessibility.Widgets.LinkLabel (_("Mouse settings…"), "settings://input/mouse");
         mouse_settings_label.vexpand = true;
 
-        //var cursor_box = new Accessibility.Widgets.SettingsBox ();
-        //cursor_size = cursor_box.add_combo_box (_("Cursor size"));
+        // var cursor_box = new Accessibility.Widgets.SettingsBox ();
+        // cursor_size = cursor_box.add_combo_box (_("Cursor size"));
 
         var control_box = new Accessibility.Widgets.SettingsBox ();
         keypad_control = control_box.add_switch (_("Control pointer using keypad"));
         speed_scale = control_box.add_scale (_("Cursor speed"), speed_adjustment);
 
-        //grid.add (cursor_box);
+        // grid.add (cursor_box);
         grid.add (control_label);
         grid.add (control_box);
         grid.add (mouse_settings_label);
@@ -67,9 +67,9 @@ public class Accessibility.Panes.Pointing : Categories.Pane {
         list_store.append (out iter);
         list_store.set (iter, 0, _("Larger"));
 
-        cursor_size.set_model (list_store);
-        cursor_size.set_active (1);
-        cursor_size.set_sensitive (false);
+        // cursor_size.set_model (list_store);
+        // cursor_size.set_active (1);
+        // cursor_size.set_sensitive (false);
     }
 
     private void connect_signals () {

--- a/src/Widgets/Categories.vala
+++ b/src/Widgets/Categories.vala
@@ -59,7 +59,11 @@ public class Accessibility.Categories : Gtk.ScrolledWindow {
         });
 
         list_box.row_selected.connect ((row) => {
-            var page = ((Pane) row);
+            var page = row as Pane;
+            if (page == null) {
+                return;
+            }
+
             if (page.added == false) {
                 page.added = true;
                 stack.add (page.pane);


### PR DESCRIPTION
This fixes warnings like `gtk_widget_set_sensitive: assertion 'GTK_IS_WIDGET (widget)' failed`. It looks like someone forgot to comment other lines that were left after commenting the unused widgets. This also fixes the segfault when you close the switchboard with the a11y plug opened by checking if the selected page is indeed a `Pane` and not an arbitrary widget.