### PR TITLE
Audio: Fix screenreader shortcut keys aren't shown

### DIFF
--- a/data/io.elementary.switchboard.a11y.appdata.xml.in
+++ b/data/io.elementary.switchboard.a11y.appdata.xml.in
@@ -7,6 +7,14 @@
   <icon type="stock">preferences-desktop-accessibility</icon>
   <translation type="gettext">accessibility-plug</translation>
   <releases>
+    <release version="2.2.1" date="2020-08-19" urgency="low">
+      <description>
+        <ul>
+          <li>Fix screenreader shortcut keys aren't shown</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.2.0" date="2020-04-01" urgency="medium">
       <description>
         <p>Remove panes whose settings now live somewhere else</p>

--- a/src/Panes/Audio.vala
+++ b/src/Panes/Audio.vala
@@ -21,6 +21,21 @@
  */
 
 public class Accessibility.Panes.Audio : Categories.Pane {
+    private static GLib.Settings media_keys_settings;
+
+    private string _screenreader_shortcut_keys = "";
+    public string screenreader_shortcut_keys {
+        get {
+            string?[] granite_accel_strings = null;
+            foreach (var key in media_keys_settings.get_strv ("screenreader")) {
+                granite_accel_strings += Granite.accel_to_string (key);
+            }
+
+            _screenreader_shortcut_keys = string.joinv (_(", "), granite_accel_strings);
+            return _screenreader_shortcut_keys;
+        }
+    }
+
     public Audio () {
         Object (
             label_string: _("Audio"),
@@ -28,14 +43,16 @@ public class Accessibility.Panes.Audio : Categories.Pane {
         );
     }
 
-    construct {
-        var media_keys_settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.media-keys");
+    static construct {
+        media_keys_settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.media-keys");
+    }
 
+    construct {
         var reader_label = new Granite.HeaderLabel (_("Screen Reader"));
 
         var reader_box = new Accessibility.Widgets.SettingsBox ();
         var read_items = reader_box.add_switch (_("Provide audio descriptions for items on the screen"));
-        var shortcut_label = new Gtk.Label (Granite.accel_to_string (media_keys_settings.get_string ("screenreader")));
+        var shortcut_label = new Gtk.Label (screenreader_shortcut_keys);
         reader_box.add_widget (_("Keyboard shortcut"), shortcut_label);
 
         var audio_settings = new Accessibility.Widgets.LinkLabel (_("Sound settings…"), "settings://sound");
@@ -49,7 +66,7 @@ public class Accessibility.Panes.Audio : Categories.Pane {
         Accessibility.Plug.applications_settings.bind ("screen-reader-enabled", read_items, "active", SettingsBindFlags.DEFAULT);
 
         media_keys_settings.changed.connect (() => {
-            shortcut_label.label = Granite.accel_to_string (media_keys_settings.get_string ("screenreader"));
+            shortcut_label.label = screenreader_shortcut_keys;
         });
     }
 }


### PR DESCRIPTION
## Before
![Screenshot from 2020-08-19 21-54-34](https://user-images.githubusercontent.com/26003928/90637276-c0f45100-e266-11ea-9dc1-e43cff273a2b.png)

Shortcut keys to show the screen reader are not shown and I got the following error message in Terminal:

```
(io.elementary.switchboard:15556): GLib-CRITICAL **: 21:54:32.467: g_variant_get_string: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_STRING) || g_variant_is_of_type (value, G_VARIANT_TYPE_OBJECT_PATH) || g_variant_is_of_type (value, G_VARIANT_TYPE_SIGNATURE)' failed
```

## After
![Screenshot from 2020-08-19 21-55-02](https://user-images.githubusercontent.com/26003928/90637282-c356ab00-e266-11ea-8334-c7c1c85c69ba.png)
